### PR TITLE
Replace step indicators with progress bar for mobile

### DIFF
--- a/components/ProgressBar.tsx
+++ b/components/ProgressBar.tsx
@@ -3,28 +3,31 @@ import { useLucide } from './useLucide'
 
 export type StepIndex = 1 | 2 | 3 | 4 | 5
 
+const STEP_LABELS: Record<StepIndex, string> = {
+  1: 'Upload',
+  2: 'Details',
+  3: 'Quote',
+  4: 'Order & Pay',
+  5: 'Confirmation',
+}
+
 export function ProgressBar({ step }: { step: StepIndex }) {
   useLucide([step])
-  const stepItem = (n: number, label: string, active: boolean) => (
-    <div className="flex items-center">
-      <div className={
-        `w-8 h-8 ${active ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-500'} rounded-full flex items-center justify-center text-sm font-medium`
-      }>{n}</div>
-      <span className={"ml-2 text-sm font-medium " + (active ? 'text-blue-600' : 'text-gray-500')}>{label}</span>
-    </div>
-  )
+  const clamped = Math.min(5, Math.max(1, step)) as StepIndex
+  const percent = ((clamped - 1) / 4) * 100
+  const label = STEP_LABELS[clamped]
+
   return (
     <div className="bg-white shadow-sm border-b">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center space-x-2 sm:space-x-4">
-            {stepItem(1, 'Upload', step >= 1)}
-            <div className="w-8 sm:w-16 h-0.5 bg-gray-200"></div>
-            {stepItem(2, 'Details', step >= 2)}
-            <div className="w-8 sm:w-16 h-0.5 bg-gray-200"></div>
-            {stepItem(3, 'Quote', step >= 3)}
-            <div className="w-8 sm:w-16 h-0.5 bg-gray-200"></div>
-            {stepItem(4, 'Order & Pay', step >= 4)}
+        <div className="relative">
+          <div className="h-3 w-full bg-gray-200 rounded-full overflow-hidden" aria-label={`Progress: Step ${clamped} of 5`} role="progressbar" aria-valuemin={0} aria-valuemax={100} aria-valuenow={Math.round(percent)}>
+            <div className="h-full bg-blue-600 rounded-full transition-all duration-300" style={{ width: `${percent}%` }} />
+          </div>
+          <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+            <span className="text-sm font-medium text-gray-700 bg-white/80 px-3 py-0.5 rounded-full">
+              Step {clamped} of 5 — {label}
+            </span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Purpose

Replace the existing step-by-step indicators with a progress bar design to resolve mobile layout issues. The new design displays the current step in the center of a progress bar, providing a more mobile-friendly and visually compact solution for the 5-step certified translation quote flow UI.

## Code changes

- **Replaced step indicators**: Removed individual step circles and labels with connecting lines
- **Added progress bar**: Implemented a horizontal progress bar with percentage-based width calculation
- **Centralized step display**: Added overlay text showing "Step X of 5 — [Label]" in the center of the progress bar
- **Added step labels mapping**: Created `STEP_LABELS` constant to map step numbers to descriptive labels (Upload, Details, Quote, Order & Pay, Confirmation)
- **Improved accessibility**: Added ARIA attributes for screen readers (role, aria-label, aria-valuemin/max/now)
- **Enhanced styling**: Added smooth transitions and responsive design with rounded progress bar and overlay stylingTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9245f98cc6ff47d3b9ca0aeaebf40fdb/stellar-home)

👀 [Preview Link](https://9245f98cc6ff47d3b9ca0aeaebf40fdb-stellar-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9245f98cc6ff47d3b9ca0aeaebf40fdb</projectId>-->
<!--<branchName>stellar-home</branchName>-->