### PR TITLE
Fix quote ID generation by using UUID instead of CS prefix

### DIFF
--- a/app/api/quote/create/route.ts
+++ b/app/api/quote/create/route.ts
@@ -1,33 +1,21 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
-
-function generateCsId() {
-  const n = Math.floor(Math.random() * 100000)
-  const digits = String(n).padStart(5, '0')
-  return `CS${digits}`
-}
+import { randomUUID } from 'crypto'
 
 export async function POST() {
   const url = process.env.SUPABASE_URL as string
   const anon = process.env.SUPABASE_ANON_KEY as string
   const client = createClient(url, anon)
 
-  let quote_id = generateCsId()
-  let attempt = 0
-  while (attempt < 10) {
-    const { error } = await client
-      .from('quote_submissions')
-      .insert({ quote_id, name: '', email: '' })
-    if (!error) return NextResponse.json({ quote_id })
-    const msg = (error && (error as any).message) || ''
-    const code = (error && (error as any).code) || ''
-    if ((code && String(code) === '23505') || /duplicate/i.test(msg)) {
-      attempt += 1
-      quote_id = generateCsId()
-      continue
-    }
-    return NextResponse.json({ error: 'DB_ERROR', details: msg || 'Unknown error' }, { status: 500 })
+  const quote_id = randomUUID()
+  const { error } = await client
+    .from('quote_submissions')
+    .insert({ quote_id, name: '', email: '' })
+
+  if (error) {
+    const msg = (error as any)?.message || 'Unknown error'
+    return NextResponse.json({ error: 'DB_ERROR', details: msg }, { status: 500 })
   }
 
-  return NextResponse.json({ error: 'ID_GENERATION_FAILED' }, { status: 500 })
+  return NextResponse.json({ quote_id })
 }


### PR DESCRIPTION
## Purpose
Fix a database error in file upload functionality where the custom CS-prefixed ID format was causing UUID validation errors. The user encountered an error: `"invalid input syntax for type uuid: \"CS55938\""` indicating the database expects proper UUID format.

## Code changes
- Replaced custom `generateCsId()` function that created CS-prefixed IDs with Node.js built-in `randomUUID()`
- Removed retry logic for duplicate ID handling since UUIDs have negligible collision probability
- Simplified error handling by removing duplicate key detection logic
- Eliminated the fallback `ID_GENERATION_FAILED` error caseTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9245f98cc6ff47d3b9ca0aeaebf40fdb/zenith-oasis)

👀 [Preview Link](https://9245f98cc6ff47d3b9ca0aeaebf40fdb-zenith-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9245f98cc6ff47d3b9ca0aeaebf40fdb</projectId>-->
<!--<branchName>zenith-oasis</branchName>-->