### PR TITLE
Add filename transmission to webhook payload

### DIFF
--- a/app/api/quote/files/route.ts
+++ b/app/api/quote/files/route.ts
@@ -58,6 +58,11 @@ export async function POST(req: NextRequest) {
       const form = new FormData()
       form.append('quote_id', quote_id)
       form.append('event', 'files_uploaded')
+      const names = rows.map(r => {
+        const display = r.filename || r.storage_path.split('/').pop() || 'upload.bin'
+        return trimName(display) || 'upload.bin'
+      })
+      form.append('filenames', JSON.stringify(names))
       for (const r of rows) {
         const { data: blob, error: dlErr } = await supabase.storage.from('orders').download(r.storage_path)
         if (dlErr || !blob) continue


### PR DESCRIPTION
## Purpose
The user requested that the webhook be updated to transmit filenames along with the existing data. This enhancement allows webhook consumers to receive file identification information when files are uploaded.

## Code changes
- Added filename extraction logic that prioritizes the stored filename field, falls back to the last segment of the storage path, or defaults to 'upload.bin'
- Applied `trimName()` function to clean up display names with fallback handling
- Appended the collected filenames as a JSON-stringified array to the webhook form data under the 'filenames' fieldTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 16`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9245f98cc6ff47d3b9ca0aeaebf40fdb/nova-lab)

👀 [Preview Link](https://9245f98cc6ff47d3b9ca0aeaebf40fdb-nova-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9245f98cc6ff47d3b9ca0aeaebf40fdb</projectId>-->
<!--<branchName>nova-lab</branchName>-->