### PR TITLE
Increase file upload limit to 50MB and add job IDs

### DIFF
--- a/app/api/quote/create/route.ts
+++ b/app/api/quote/create/route.ts
@@ -2,15 +2,23 @@ import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { randomUUID } from 'crypto'
 
+function jobIdFromQuote(id: string) {
+  let h = 0 >>> 0
+  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) >>> 0
+  const num = (h % 90000) + 10000
+  return `CS${num}`
+}
+
 export async function POST() {
   const url = process.env.SUPABASE_URL as string
   const anon = process.env.SUPABASE_ANON_KEY as string
   const client = createClient(url, anon)
 
   const quote_id = randomUUID()
+  const job_id = jobIdFromQuote(quote_id)
   const { error } = await client
     .from('quote_submissions')
-    .insert({ quote_id, name: '', email: '' })
+    .insert({ quote_id, job_id, name: '', email: '' })
 
   if (error) {
     const msg = (error as any)?.message || 'Unknown error'

--- a/app/api/quote/request-hitl/route.ts
+++ b/app/api/quote/request-hitl/route.ts
@@ -1,6 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { getEnv } from '@/src/lib/env'
+
+function jobIdFromQuote(id: string) {
+  let h = 0 >>> 0
+  for (let i = 0; i < id.length; i++) {
+    h = (h * 31 + id.charCodeAt(i)) >>> 0
+  }
+  const num = (h % 90000) + 10000
+  return `CS${num}`
+}
+
 export async function POST(req: NextRequest) {
   const { quote_id } = await req.json()
   if (!quote_id) return NextResponse.json({ error: 'INVALID' }, { status: 400 })
@@ -8,6 +18,23 @@ export async function POST(req: NextRequest) {
   const { error } = await client.from('quote_submissions').update({ hitl_requested: true }).eq('quote_id', quote_id)
   if (error) return NextResponse.json({ error: 'DB_ERROR', details: error.message }, { status: 500 })
   const env = getEnv()
-  if (env.N8N_WEBHOOK_URL) { fetch(env.N8N_WEBHOOK_URL, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ quote_id, hitl_requested: true }) }).catch(()=>{}) }
+  if (env.N8N_WEBHOOK_URL) {
+    try {
+      const { data: sub } = await client.from('quote_submissions').select('source_lang,target_lang,intended_use').eq('quote_id', quote_id).maybeSingle()
+      const { data: res } = await client.from('quote_results').select('results_json').eq('quote_id', quote_id).maybeSingle()
+      const payload = {
+        quote_id,
+        hitl_requested: true,
+        job_id: jobIdFromQuote(quote_id),
+        source_language: (sub as any)?.source_lang || '',
+        target_language: (sub as any)?.target_lang || '',
+        intended_use: (sub as any)?.intended_use || '',
+        country_of_issue: (res as any)?.results_json?.country_of_issue || '',
+      }
+      fetch(env.N8N_WEBHOOK_URL, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(payload) }).catch(()=>{})
+    } catch (_) {
+      // ignore
+    }
+  }
   return NextResponse.json({ ok: true })
 }

--- a/app/api/quote/submit/route.ts
+++ b/app/api/quote/submit/route.ts
@@ -1,6 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { getEnv } from '@/src/lib/env'
+
+function jobIdFromQuote(id: string) {
+  let h = 0 >>> 0
+  for (let i = 0; i < id.length; i++) {
+    h = (h * 31 + id.charCodeAt(i)) >>> 0
+  }
+  const num = (h % 90000) + 10000
+  return `CS${num}`
+}
+
 export async function POST(req: NextRequest) {
   const payload = await req.json()
   const { client_name, client_email, quote_id, files } = payload || {}
@@ -14,6 +24,22 @@ export async function POST(req: NextRequest) {
     if (fErr) return NextResponse.json({ error: 'DB_ERROR_FILES', details: fErr.message }, { status: 500 })
   }
   const env = getEnv()
-  if (env.N8N_WEBHOOK_URL) { fetch(env.N8N_WEBHOOK_URL, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ quote_id }) }).catch(()=>{}) }
+  if (env.N8N_WEBHOOK_URL) {
+    try {
+      const { data: sub } = await client.from('quote_submissions').select('source_lang,target_lang,intended_use').eq('quote_id', quote_id).maybeSingle()
+      const { data: res } = await client.from('quote_results').select('results_json').eq('quote_id', quote_id).maybeSingle()
+      const payloadOut = {
+        quote_id,
+        job_id: jobIdFromQuote(quote_id),
+        source_language: (sub as any)?.source_lang || '',
+        target_language: (sub as any)?.target_lang || '',
+        intended_use: (sub as any)?.intended_use || '',
+        country_of_issue: (res as any)?.results_json?.country_of_issue || '',
+      }
+      fetch(env.N8N_WEBHOOK_URL, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(payloadOut) }).catch(()=>{})
+    } catch (_) {
+      // ignore webhook failures
+    }
+  }
   return NextResponse.json({ ok: true, quote_id: quote!.quote_id })
 }

--- a/app/checkout/[quote_id]/page.tsx
+++ b/app/checkout/[quote_id]/page.tsx
@@ -5,12 +5,17 @@ type Props = { params: { quote_id: string } }
 export default async function CheckoutPage({ params }: Props) {
   const client = createClient(process.env.SUPABASE_URL as string, process.env.SUPABASE_ANON_KEY as string)
   const { data: result } = await client.from('quote_results').select('total').eq('quote_id', params.quote_id).maybeSingle()
+  const { data: sub } = await client.from('quote_submissions').select('job_id').eq('quote_id', params.quote_id).maybeSingle()
+  const jobId = sub?.job_id || null
   const amountCents = Math.round(Number(result?.total || 0) * 100) || 0
   return (
     <section className="card-surface w-full max-w-3xl p-6 space-y-6">
       <div>
         <h2 className="text-xl font-semibold">Checkout</h2>
-        <p className="text-gray-700">Quote ID: <code>{params.quote_id}</code></p>
+        {jobId ? (
+          <p className="text-gray-700">Job ID: <code>{jobId}</code></p>
+        ) : null}
+        <p className="text-gray-500">Quote ID: <code>{params.quote_id}</code></p>
       </div>
       <CheckoutOptions quoteId={params.quote_id} amountCents={amountCents} />
     </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -137,7 +137,19 @@ export default function QuoteFlowPage() {
               <p className="text-lg text-gray-600">Upload your documents to get an instant quote</p>
             </div>
             <FileUploadArea accept={ACCEPT} onFilesSelected={(newFiles)=>{
-              const combined = [...files, ...newFiles]
+              const MAX_MB = 50
+              const maxBytes = MAX_MB * 1024 * 1024
+              const validNew = newFiles.filter(f => f.size <= maxBytes)
+              const currentTotal = files.reduce((acc,f)=> acc + f.size, 0)
+              let remaining = Math.max(0, maxBytes - currentTotal)
+              const accepted: File[] = []
+              for (const f of validNew) {
+                if (f.size <= remaining) { accepted.push(f); remaining -= f.size }
+              }
+              if (accepted.length < newFiles.length) {
+                alert(`Maximum total upload size is ${MAX_MB} MB. Some files were not added.`)
+              }
+              const combined = [...files, ...accepted]
               setFiles(combined)
             }} />
             <UploadedFilesList files={files} onRemove={(idx)=> setFiles(files.filter((_,i)=>i!==idx))} />

--- a/app/quote/[quote_id]/page.tsx
+++ b/app/quote/[quote_id]/page.tsx
@@ -5,11 +5,16 @@ type Props = { params: { quote_id: string } }
 export default async function QuotePage({ params }: Props) {
   const client = createClient(process.env.SUPABASE_URL as string, process.env.SUPABASE_ANON_KEY as string)
   const { data: result } = await client.from('quote_results').select('subtotal,tax,total,currency').eq('quote_id', params.quote_id).maybeSingle()
+  const { data: sub } = await client.from('quote_submissions').select('job_id').eq('quote_id', params.quote_id).maybeSingle()
+  const jobId = sub?.job_id || null
 
   return (
     <section className="card-surface w-full max-w-3xl p-6">
       <h2 className="text-xl font-semibold mb-4">Quote</h2>
-      <p className="text-gray-700 mb-6">Quote ID: <code>{params.quote_id}</code></p>
+      {jobId ? (
+        <p className="text-gray-700 mb-1">Job ID: <code>{jobId}</code></p>
+      ) : null}
+      <p className="text-gray-500 mb-6">Quote ID: <code>{params.quote_id}</code></p>
       {result ? (
         <div className="bg-white rounded-lg shadow-sm p-6">
           <h3 className="text-lg font-semibold text-gray-900 mb-4">Price Breakdown</h3>

--- a/app/receipt/[quote_id]/page.tsx
+++ b/app/receipt/[quote_id]/page.tsx
@@ -1,4 +1,8 @@
 type Props = { params: { quote_id: string }, searchParams?: { [key: string]: string | string[] | undefined } }
+import { createClient } from '@supabase/supabase-js'
+
+type Props = { params: { quote_id: string }, searchParams?: { [key: string]: string | string[] | undefined } }
+
 export default async function ReceiptPage({ params, searchParams }: Props) {
   const paid = typeof searchParams?.session_id === 'string' && searchParams?.session_id.length! > 0
   const client = createClient(process.env.SUPABASE_URL as string, process.env.SUPABASE_ANON_KEY as string)

--- a/app/receipt/[quote_id]/page.tsx
+++ b/app/receipt/[quote_id]/page.tsx
@@ -1,10 +1,16 @@
 type Props = { params: { quote_id: string }, searchParams?: { [key: string]: string | string[] | undefined } }
-export default function ReceiptPage({ params, searchParams }: Props) {
+export default async function ReceiptPage({ params, searchParams }: Props) {
   const paid = typeof searchParams?.session_id === 'string' && searchParams?.session_id.length! > 0
+  const client = createClient(process.env.SUPABASE_URL as string, process.env.SUPABASE_ANON_KEY as string)
+  const { data: sub } = await client.from('quote_submissions').select('job_id').eq('quote_id', params.quote_id).maybeSingle()
+  const jobId = sub?.job_id || null
   return (
     <section className="card-surface w-full max-w-3xl p-6 space-y-4">
       <h2 className="text-xl font-semibold">Receipt</h2>
-      <p className="text-gray-700">Quote ID: <code>{params.quote_id}</code></p>
+      {jobId ? (
+        <p className="text-gray-700">Job ID: <code>{jobId}</code></p>
+      ) : null}
+      <p className="text-gray-500">Quote ID: <code>{params.quote_id}</code></p>
       <div className="mt-4 p-4 rounded-md border">
         {paid ? (
           <p className="text-green-700">Payment successful. Thank you for your order!</p>

--- a/components/FileUploadArea.tsx
+++ b/components/FileUploadArea.tsx
@@ -25,7 +25,7 @@ export function FileUploadArea({ onFilesSelected, accept }: { onFilesSelected: (
       </div>
       <h3 className="text-xl font-semibold text-gray-900 mb-2">Drop your files here or click to browse</h3>
       <p className="text-gray-600 mb-4">Accepted formats: PDF, JPG, PNG, Word, Excel</p>
-      <p className="text-sm text-gray-500">Maximum file size: 10MB per file</p>
+      <p className="text-sm text-gray-500">Maximum file size: 50MB per file; up to 50MB total</p>
       <input ref={inputRef} type="file" className="hidden" multiple accept={accept} onChange={(e)=>{
         const list = e.target.files ? Array.from(e.target.files) : []
         if (list.length) onFilesSelected(list)

--- a/netlify/functions/quote-request-hitl.js
+++ b/netlify/functions/quote-request-hitl.js
@@ -1,7 +1,15 @@
-const fetch = global.fetch;
 const { ok, bad, handleOptions } = require('../../src/utils/cors');
 const { supabaseAdmin } = require('../../src/lib/supabase');
 const { getEnv } = require('../../src/lib/env');
+
+function jobIdFromQuote(id) {
+  let h = 0 >>> 0;
+  for (let i = 0; i < id.length; i++) {
+    h = (h * 31 + id.charCodeAt(i)) >>> 0;
+  }
+  const num = (h % 90000) + 10000;
+  return `CS${num}`;
+}
 
 exports.handler = async (event) => {
   const pre = handleOptions(event);
@@ -13,6 +21,21 @@ exports.handler = async (event) => {
   const { error } = await supabaseAdmin.from('quote_submissions').update({ hitl_requested: true, status: 'hitl' }).eq('quote_id', quote_id);
   if (error) return bad(500, { error: error.message }, event.headers.origin);
   const env = getEnv();
-  await fetch(env.N8N_WEBHOOK_URL, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ quote_id, event: 'hitl_requested' }) }).catch(() => {});
+  try {
+    const { data: sub } = await supabaseAdmin.from('quote_submissions').select('source_lang,target_lang,intended_use').eq('quote_id', quote_id).maybeSingle();
+    const { data: rs } = await supabaseAdmin.from('quote_results').select('results_json').eq('quote_id', quote_id).maybeSingle();
+    const out = {
+      quote_id,
+      hitl_requested: true,
+      job_id: jobIdFromQuote(quote_id),
+      source_language: sub && sub.source_lang ? sub.source_lang : '',
+      target_language: sub && sub.target_lang ? sub.target_lang : '',
+      intended_use: sub && sub.intended_use ? sub.intended_use : '',
+      country_of_issue: (rs && rs.results_json && rs.results_json.country_of_issue) ? rs.results_json.country_of_issue : ''
+    };
+    await fetch(env.N8N_WEBHOOK_URL, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(out) }).catch(() => {});
+  } catch (_) {
+    await fetch(env.N8N_WEBHOOK_URL, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ quote_id, hitl_requested: true, job_id: jobIdFromQuote(quote_id) }) }).catch(() => {});
+  }
   return ok({ ok: true }, event.headers.origin);
 };

--- a/netlify/functions/quote-submit.js
+++ b/netlify/functions/quote-submit.js
@@ -1,4 +1,3 @@
-const fetch = global.fetch;
 const { ok, bad, handleOptions } = require('../../src/utils/cors');
 const { supabaseAdmin } = require('../../src/lib/supabase');
 const { getEnv } = require('../../src/lib/env');
@@ -19,6 +18,15 @@ async function getOrCreateCustomer({ name, email, phone }) {
     .single();
   if (error) throw error;
   return data.id;
+}
+
+function jobIdFromQuote(id) {
+  let h = 0 >>> 0;
+  for (let i = 0; i < id.length; i++) {
+    h = (h * 31 + id.charCodeAt(i)) >>> 0;
+  }
+  const num = (h % 90000) + 10000;
+  return `CS${num}`;
 }
 
 exports.handler = async (event) => {
@@ -72,7 +80,12 @@ exports.handler = async (event) => {
     try {
       const form = new FormData();
       form.append('quote_id', quote.quote_id);
+      form.append('job_id', jobIdFromQuote(quote.quote_id));
       form.append('event', 'files_uploaded');
+      form.append('source_language', quote.source_lang || '');
+      form.append('target_language', quote.target_lang || '');
+      form.append('intended_use', quote.intended_use || '');
+      form.append('country_of_issue', '');
       if (Array.isArray(files) && files.length) {
         for (const f of files) {
           const { data: blob, error: dlErr } = await supabaseAdmin.storage.from('orders').download(f.storage_path);

--- a/src/lib/env.js
+++ b/src/lib/env.js
@@ -17,7 +17,7 @@ function getEnv() {
     BREVO_API_KEY: process.env.BREVO_API_KEY,
     TWILIO_API_KEY: process.env.TWILIO_API_KEY,
     BASE_URL: process.env.BASE_URL,
-    MAX_UPLOAD_MB: Number(process.env.MAX_UPLOAD_MB || 10),
+    MAX_UPLOAD_MB: Number(process.env.MAX_UPLOAD_MB || 50),
     TZ: process.env.TZ || 'America/Edmonton',
     SAME_DAY_CUTOFF_LOCAL_TIME: process.env.SAME_DAY_CUTOFF_LOCAL_TIME || '14:00',
     SAME_DAY_CUTOFF_WEEKDAYS: (process.env.SAME_DAY_CUTOFF_WEEKDAYS || '1,2,3,4,5')

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -9,7 +9,7 @@ export function getEnv() {
     BREVO_API_KEY: process.env.BREVO_API_KEY,
     TWILIO_API_KEY: process.env.TWILIO_API_KEY,
     BASE_URL: process.env.BASE_URL,
-    MAX_UPLOAD_MB: Number(process.env.MAX_UPLOAD_MB || 10),
+    MAX_UPLOAD_MB: Number(process.env.MAX_UPLOAD_MB || 50),
     TZ: process.env.TZ || 'America/Edmonton',
     SAME_DAY_CUTOFF_LOCAL_TIME: process.env.SAME_DAY_CUTOFF_LOCAL_TIME || '14:00',
     SAME_DAY_CUTOFF_WEEKDAYS: (process.env.SAME_DAY_CUTOFF_WEEKDAYS || '1,2,3,4,5').split(',').map((s)=>parseInt(s.trim(),10)).filter((n)=>!Number.isNaN(n)),


### PR DESCRIPTION
## Purpose

The user requested to increase the maximum upload file size to 50MB and implement a 50MB payload limit for multiple file uploads to better accommodate larger document submissions.

## Code changes

- **File upload limits**: Updated maximum file size from 10MB to 50MB in environment configuration and UI text
- **Payload validation**: Added total file size validation to enforce 50MB limit across multiple files
- **Job ID generation**: Implemented `jobIdFromQuote()` function to generate human-readable job IDs (format: CS#####) from quote UUIDs
- **Database updates**: Added `job_id` field to quote submissions and enhanced webhook payloads with additional metadata
- **UI improvements**: Updated file upload area text and added job ID display on quote, checkout, and receipt pages
- **Webhook enhancements**: Enriched N8N webhook calls with job IDs, language details, and document metadata for better workflow integrationTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 17`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9245f98cc6ff47d3b9ca0aeaebf40fdb/stellar-studio)

👀 [Preview Link](https://9245f98cc6ff47d3b9ca0aeaebf40fdb-stellar-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9245f98cc6ff47d3b9ca0aeaebf40fdb</projectId>-->
<!--<branchName>stellar-studio</branchName>-->