### PR TITLE
Fix webhook firing and add language schema flexibility

### DIFF
--- a/app/api/languages/route.ts
+++ b/app/api/languages/route.ts
@@ -6,7 +6,17 @@ export async function GET() {
   const anon = process.env.SUPABASE_ANON_KEY as string
   if (!url || !anon) return NextResponse.json({ error: 'MISSING_ENV' }, { status: 500 })
   const client = createClient(url, anon)
-  const { data, error } = await client.from('languages').select('id,name,iso_code').order('name', { ascending: true })
+
+  // Select all columns to avoid column mismatch errors across schemas, then normalize
+  const { data, error } = await client.from('languages').select('*')
   if (error) return NextResponse.json({ error: 'DB_ERROR', details: error.message }, { status: 500 })
-  return NextResponse.json({ languages: data || [] })
+
+  const rows = (data || []).map((r: any) => {
+    const name: string = r.name ?? r.label ?? r.language ?? r.display_name ?? r.title ?? String(r.id)
+    const iso_code: string | null = r.iso_code ?? r.iso ?? r.code ?? r.lang_code ?? null
+    return { id: r.id, name, iso_code }
+  })
+
+  rows.sort((a, b) => a.name.localeCompare(b.name))
+  return NextResponse.json({ languages: rows })
 }


### PR DESCRIPTION
## Purpose
Fix webhook firing issues where the workflow only executes when manually clicked/tested, and improve language API robustness to handle different database schema configurations.

## Code changes
- **Languages API**: Modified to select all columns and normalize field names to handle schema variations (name/label/language, iso_code/iso/code) with fallback logic
- **Quote files webhook**: Enhanced webhook payload with additional context (event type, language info, intended use, country) and added production fallback URL logic for test environments
- **Webhook retry mechanism**: Improved error handling with fallback URL attempts and better retry logic to ensure webhook fires reliablyTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 22`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9245f98cc6ff47d3b9ca0aeaebf40fdb/flare-haven)

👀 [Preview Link](https://9245f98cc6ff47d3b9ca0aeaebf40fdb-flare-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9245f98cc6ff47d3b9ca0aeaebf40fdb</projectId>-->
<!--<branchName>flare-haven</branchName>-->