### PR TITLE
Add TypeScript definitions for utif to resolve Netlify build type error

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/react": "^18.3.8",
     "@types/react-dom": "^18.3.0",
     "@types/pngjs": "^6.0.5",
+    "@types/utif": "^3.0.6",
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.13",


### PR DESCRIPTION
cgen-8b19813a2d204dc2b4feec11c0d38883