### PR TITLE
Fix TypeScript null handling in quote upload flow

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -80,11 +80,14 @@ export default function QuoteFlowPage() {
     setOverlayMode('upload')
     setProcessingOpen(true)
     try {
-      let quote_id = quoteId
-      if (!quote_id) {
+      let quote_id: string
+      if (quoteId) {
+        quote_id = quoteId
+      } else {
         const createRes = await fetch('/api/quote/create', { method: 'POST' })
         if (!createRes.ok) throw new Error('CREATE_FAILED')
         const json = await createRes.json()
+        if (!json?.quote_id || typeof json.quote_id !== 'string') throw new Error('CREATE_NO_ID')
         quote_id = json.quote_id
       }
       const uploaded: { path: string; contentType: string; filename: string; bytes: number }[] = []


### PR DESCRIPTION
## Purpose
Fix a Netlify build failure caused by a TypeScript error where a `string | null` type was being passed to a function expecting a `string`. The user needed to resolve the type safety issue in the quote upload flow to enable successful deployment.

## Code changes
- Added explicit type annotation for `quote_id` variable as `string`
- Restructured conditional logic to ensure `quote_id` is always assigned a string value
- Added validation check for the API response to ensure `json.quote_id` exists and is a string type
- Added error handling with `CREATE_NO_ID` error for invalid API responses

These changes ensure type safety and prevent null values from being passed to functions expecting strings.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 32`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9245f98cc6ff47d3b9ca0aeaebf40fdb/zen-verse)

👀 [Preview Link](https://9245f98cc6ff47d3b9ca0aeaebf40fdb-zen-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9245f98cc6ff47d3b9ca0aeaebf40fdb</projectId>-->
<!--<branchName>zen-verse</branchName>-->