### PR TITLE
Replace useLucide with Icon component for better performance

### DIFF
--- a/components/ConfirmationPage.tsx
+++ b/components/ConfirmationPage.tsx
@@ -1,12 +1,11 @@
 "use client"
-import { useLucide } from './useLucide'
+import { Icon } from './Icon'
 
 export function ConfirmationPage({ orderNumber, totalPaid, timeline }: { orderNumber: string; totalPaid: number; timeline: string }) {
-  useLucide([orderNumber])
   return (
     <div className="text-center">
       <div className="mx-auto w-20 h-20 bg-green-100 rounded-full flex items-center justify-center mb-6">
-        <i data-lucide="check" className="w-10 h-10 text-green-600"></i>
+        <Icon name="check" className="w-10 h-10 text-green-600" />
       </div>
       <h2 className="text-3xl font-bold text-gray-900 mb-4">Thank You!</h2>
       <p className="text-lg text-gray-600 mb-8">Your order has been successfully placed and payment confirmed.</p>

--- a/components/FileUploadArea.tsx
+++ b/components/FileUploadArea.tsx
@@ -1,9 +1,8 @@
 "use client"
 import { useCallback, useRef } from 'react'
-import { useLucide } from './useLucide'
+import { Icon } from './Icon'
 
 export function FileUploadArea({ onFilesSelected, accept }: { onFilesSelected: (files: File[]) => void, accept: string }) {
-  useLucide([])
   const inputRef = useRef<HTMLInputElement>(null)
 
   const onDrop = useCallback((e: React.DragEvent) => {
@@ -21,7 +20,7 @@ export function FileUploadArea({ onFilesSelected, accept }: { onFilesSelected: (
       className="bg-white rounded-lg shadow-sm border-2 border-dashed border-gray-300 p-8 text-center hover:border-blue-400 transition-colors cursor-pointer"
     >
       <div className="mx-auto w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mb-4">
-        <i data-lucide="upload" className="w-8 h-8 text-blue-600"></i>
+        <Icon name="upload" className="w-8 h-8 text-blue-600" />
       </div>
       <h3 className="text-xl font-semibold text-gray-900 mb-2">Drop your files here or click to browse</h3>
       <p className="text-gray-600 mb-4">Accepted formats: PDF, JPG, PNG, Word, Excel</p>

--- a/components/Icon.tsx
+++ b/components/Icon.tsx
@@ -47,7 +47,7 @@ export function Icon({ name, className }: { name: IconName; className?: string }
       return (
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
           <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
-          <path d="M12 7a4 4 0 1 0 0-8 4 4 0 0 0 0 8z" transform="translate(0 5)" />
+          <circle cx="12" cy="7" r="4" />
         </svg>
       )
     case 'upload':

--- a/components/Icon.tsx
+++ b/components/Icon.tsx
@@ -1,0 +1,64 @@
+"use client"
+import React from 'react'
+
+export type IconName = 'check' | 'file-text' | 'x' | 'download' | 'mail' | 'user' | 'upload'
+
+export function Icon({ name, className }: { name: IconName; className?: string }) {
+  switch (name) {
+    case 'check':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+          <path d="M20 6L9 17l-5-5" />
+        </svg>
+      )
+    case 'file-text':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+          <path d="M14 2v6h6" />
+          <path d="M16 13H8" />
+          <path d="M16 17H8" />
+          <path d="M10 9H8" />
+        </svg>
+      )
+    case 'x':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+          <path d="M18 6L6 18" />
+          <path d="M6 6l12 12" />
+        </svg>
+      )
+    case 'download':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+          <path d="M7 10l5 5 5-5" />
+          <path d="M12 15V3" />
+        </svg>
+      )
+    case 'mail':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+          <path d="M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z" />
+          <path d="M22 6l-10 7L2 6" />
+        </svg>
+      )
+    case 'user':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+          <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+          <path d="M12 7a4 4 0 1 0 0-8 4 4 0 0 0 0 8z" transform="translate(0 5)" />
+        </svg>
+      )
+    case 'upload':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+          <path d="M7 10l5-5 5 5" />
+          <path d="M12 5v14" />
+        </svg>
+      )
+    default:
+      return null
+  }
+}

--- a/components/OtpModal.tsx
+++ b/components/OtpModal.tsx
@@ -1,9 +1,7 @@
 "use client"
 import { useEffect, useRef, useState } from 'react'
-import { useLucide } from './useLucide'
 
 export function OtpModal({ open, onVerify, onClose, onResend }: { open: boolean; onVerify: (code: string) => void; onClose: () => void; onResend: () => void }) {
-  useLucide([open])
   const inputsRef = useRef<Array<HTMLInputElement | null>>([])
   const [digits, setDigits] = useState<string[]>(['','','','','',''])
 

--- a/components/ProcessingOverlay.tsx
+++ b/components/ProcessingOverlay.tsx
@@ -1,6 +1,6 @@
 "use client"
 import { useEffect, useRef, useState } from 'react'
-import { useLucide } from './useLucide'
+import { Icon } from './Icon'
 
 const STEPS = [
   { id: 'analyzing', label: 'Analyzing your documents...', duration: 2000 },
@@ -13,7 +13,6 @@ export function ProcessingOverlay({ open, onDone, mode = 'process' }: { open: bo
   const [current, setCurrent] = useState(0)
   const [progress, setProgress] = useState(0)
   const timer = useRef<any>(null)
-  useLucide([open, current, mode])
 
   useEffect(()=>{
     if (!open) return
@@ -56,7 +55,7 @@ export function ProcessingOverlay({ open, onDone, mode = 'process' }: { open: bo
           {(mode === 'upload' ? UPLOAD_STEPS : PROCESS_STEPS).map((s, i)=> (
             <div key={s.id} className={'flex items-center justify-center space-x-3 ' + (i <= current ? '' : 'opacity-50')}>
               <div className={i <= current ? 'w-6 h-6 bg-blue-600 rounded-full flex items-center justify-center' : 'w-6 h-6 border-2 border-gray-300 rounded-full flex items-center justify-center'}>
-                {i < current ? (<i data-lucide="check" className="w-4 h-4 text-white"></i>) : (<div className={i === current ? 'w-2 h-2 bg-blue-600 rounded-full animate-pulse' : 'w-2 h-2 bg-gray-300 rounded-full'}></div>)}
+                {i < current ? (<Icon name="check" className="w-4 h-4 text-white" />) : (<div className={i === current ? 'w-2 h-2 bg-blue-600 rounded-full animate-pulse' : 'w-2 h-2 bg-gray-300 rounded-full'}></div>)}
               </div>
               <span className={'text-lg font-medium ' + (i <= current ? 'text-gray-900' : 'text-gray-600')}>{s.label}</span>
             </div>

--- a/components/ProgressBar.tsx
+++ b/components/ProgressBar.tsx
@@ -1,5 +1,4 @@
 "use client"
-import { useLucide } from './useLucide'
 
 export type StepIndex = 1 | 2 | 3 | 4 | 5
 
@@ -12,7 +11,6 @@ const STEP_LABELS: Record<StepIndex, string> = {
 }
 
 export function ProgressBar({ step }: { step: StepIndex }) {
-  useLucide([step])
   const clamped = Math.min(5, Math.max(1, step)) as StepIndex
   const percent = ((clamped - 1) / 4) * 100
   const label = STEP_LABELS[clamped]

--- a/components/QuoteReviewCard.tsx
+++ b/components/QuoteReviewCard.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { useLucide } from './useLucide'
+import { Icon } from './Icon'
 
 export type QuoteDetails = {
   price: number
@@ -11,7 +11,6 @@ export type QuoteDetails = {
 }
 
 export function QuoteReviewCard({ details, onAccept }: { details: QuoteDetails; onAccept: () => void }) {
-  useLucide([details])
   const priceFmt = `$${details.price.toFixed(2)}`
   return (
     <div className="bg-white rounded-lg shadow-sm p-6 md:p-8">
@@ -32,9 +31,9 @@ export function QuoteReviewCard({ details, onAccept }: { details: QuoteDetails; 
         <button onClick={onAccept} className="bg-green-600 text-white py-4 px-8 rounded-lg text-lg font-semibold hover:bg-green-700 transition-colors shadow-lg">Accept & Proceed</button>
       </div>
       <div className="flex flex-col sm:flex-row items-center justify-center space-y-3 sm:space-y-0 sm:space-x-8 text-center">
-        <a href="#" className="text-blue-600 hover:text-blue-800 hover:underline font-medium flex items-center"><i data-lucide="download" className="w-4 h-4 mr-2"></i>Save Quote</a>
-        <a href="#" className="text-blue-600 hover:text-blue-800 hover:underline font-medium flex items-center"><i data-lucide="mail" className="w-4 h-4 mr-2"></i>Email Quote</a>
-        <a href="#" className="text-blue-600 hover:text-blue-800 hover:underline font-medium flex items-center"><i data-lucide="user" className="w-4 h-4 mr-2"></i>Request Human Review</a>
+        <a href="#" className="text-blue-600 hover:text-blue-800 hover:underline font-medium flex items-center"><Icon name="download" className="w-4 h-4 mr-2" />Save Quote</a>
+        <a href="#" className="text-blue-600 hover:text-blue-800 hover:underline font-medium flex items-center"><Icon name="mail" className="w-4 h-4 mr-2" />Email Quote</a>
+        <a href="#" className="text-blue-600 hover:text-blue-800 hover:underline font-medium flex items-center"><Icon name="user" className="w-4 h-4 mr-2" />Request Human Review</a>
       </div>
     </div>
   )

--- a/components/UploadedFilesList.tsx
+++ b/components/UploadedFilesList.tsx
@@ -1,8 +1,7 @@
 "use client"
-import { useLucide } from './useLucide'
+import { Icon } from './Icon'
 
 export function UploadedFilesList({ files, onRemove }: { files: File[]; onRemove: (idx: number) => void }) {
-  useLucide([files.length])
   if (!files.length) return null
   return (
     <div className="mt-6">
@@ -11,14 +10,14 @@ export function UploadedFilesList({ files, onRemove }: { files: File[]; onRemove
         {files.map((file, idx) => (
           <div key={idx} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
             <div className="flex items-center">
-              <i data-lucide="file-text" className="w-5 h-5 text-gray-500 mr-3"></i>
+              <Icon name="file-text" className="w-5 h-5 text-gray-500 mr-3" />
               <div>
                 <div className="font-medium text-gray-900">{file.name}</div>
                 <div className="text-sm text-gray-500">{(file.size / 1024 / 1024).toFixed(2)} MB</div>
               </div>
             </div>
             <button onClick={()=>onRemove(idx)} className="text-red-500 hover:text-red-700">
-              <i data-lucide="x" className="w-5 h-5"></i>
+              <Icon name="x" className="w-5 h-5" />
             </button>
           </div>
         ))}


### PR DESCRIPTION
## Purpose
Fix runtime error by replacing the problematic `useLucide` hook with a more reliable icon implementation. The user encountered a runtime error that needed to be resolved.

## Code changes
- **Removed `useLucide` hook**: Eliminated all imports and usage of the `useLucide` hook across multiple components
- **Created new `Icon` component**: Added a new self-contained Icon component with inline SVG definitions for common icons (check, file-text, x, download, mail, user, upload)
- **Updated icon usage**: Replaced all `<i data-lucide="...">` elements with the new `<Icon name="..." />` component
- **Cleaned up dependencies**: Removed unnecessary `useLucide([...])` calls that were causing the runtime issues

**Files modified:**
- `components/ConfirmationPage.tsx`
- `components/FileUploadArea.tsx` 
- `components/OtpModal.tsx`
- `components/ProcessingOverlay.tsx`
- `components/ProgressBar.tsx`
- `components/QuoteReviewCard.tsx`
- `components/UploadedFilesList.tsx`
- `components/Icon.tsx` (new file)

This change eliminates the runtime error while maintaining the same visual appearance and functionality.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 33`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9245f98cc6ff47d3b9ca0aeaebf40fdb/zenith-home)

👀 [Preview Link](https://9245f98cc6ff47d3b9ca0aeaebf40fdb-zenith-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9245f98cc6ff47d3b9ca0aeaebf40fdb</projectId>-->
<!--<branchName>zenith-home</branchName>-->