### PR TITLE
Fix quote creation DB error and simplify schema

### DIFF
--- a/app/api/quote/create/route.ts
+++ b/app/api/quote/create/route.ts
@@ -27,6 +27,7 @@ export async function POST() {
   const { error } = await client.from('quote_submissions').insert(insertRow)
 
   if (error) {
+    console.error('QUOTE_CREATE_DB_ERROR', { details: (error as any)?.message, code: (error as any)?.code })
     const msg = (error as any)?.message || 'Unknown error'
     return NextResponse.json({ error: 'DB_ERROR', details: msg }, { status: 500 })
   }

--- a/app/api/quote/create/route.ts
+++ b/app/api/quote/create/route.ts
@@ -2,29 +2,22 @@ import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { randomUUID } from 'crypto'
 
-function jobIdFromQuote(id: string) {
-  let h = 0 >>> 0
-  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) >>> 0
-  const num = (h % 90000) + 10000
-  return `CS${num}`
-}
-
 export async function POST() {
   const url = process.env.SUPABASE_URL as string
   const service = (process.env.SUPABASE_SERVICE_ROLE_KEY as string) || (process.env.SUPABASE_ANON_KEY as string)
   const client = createClient(url, service, { auth: { persistSession: false, autoRefreshToken: false } })
 
   const quote_id = randomUUID()
-  const job_id = jobIdFromQuote(quote_id)
+
   const insertRow = {
     quote_id,
-    job_id,
     client_name: '',
     client_email: '',
     source_lang: '',
     target_lang: '',
     intended_use: ''
   }
+
   const { error } = await client.from('quote_submissions').insert(insertRow)
 
   if (error) {
@@ -32,5 +25,5 @@ export async function POST() {
     return NextResponse.json({ error: 'DB_ERROR', details: msg }, { status: 500 })
   }
 
-  return NextResponse.json({ quote_id, job_id })
+  return NextResponse.json({ quote_id })
 }

--- a/app/api/quote/create/route.ts
+++ b/app/api/quote/create/route.ts
@@ -20,15 +20,8 @@ export async function POST() {
   const insertRow = {
     quote_id,
     job_id,
-    // DB requires non-null name/email in this project
     name: '',
-    email: '',
-    // Keep legacy fields too for compatibility
-    client_name: '',
-    client_email: '',
-    source_lang: '',
-    target_lang: '',
-    intended_use: ''
+    email: ''
   }
 
   const { error } = await client.from('quote_submissions').insert(insertRow)

--- a/app/api/quote/create/route.ts
+++ b/app/api/quote/create/route.ts
@@ -2,15 +2,28 @@ import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { randomUUID } from 'crypto'
 
+function jobIdFromQuote(id: string) {
+  let h = 0 >>> 0
+  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) >>> 0
+  const num = (h % 90000) + 10000
+  return `CS${num}`
+}
+
 export async function POST() {
   const url = process.env.SUPABASE_URL as string
   const service = (process.env.SUPABASE_SERVICE_ROLE_KEY as string) || (process.env.SUPABASE_ANON_KEY as string)
   const client = createClient(url, service, { auth: { persistSession: false, autoRefreshToken: false } })
 
   const quote_id = randomUUID()
+  const job_id = jobIdFromQuote(quote_id)
 
   const insertRow = {
     quote_id,
+    job_id,
+    // DB requires non-null name/email in this project
+    name: '',
+    email: '',
+    // Keep legacy fields too for compatibility
     client_name: '',
     client_email: '',
     source_lang: '',
@@ -25,5 +38,5 @@ export async function POST() {
     return NextResponse.json({ error: 'DB_ERROR', details: msg }, { status: 500 })
   }
 
-  return NextResponse.json({ quote_id })
+  return NextResponse.json({ quote_id, job_id })
 }


### PR DESCRIPTION
## Purpose
Fix a runtime error occurring during quote creation process. The error was happening in step 1 when firing webhooks, storing files, and creating a row in Supabase database.

## Code changes
- **Simplified database schema**: Removed unnecessary fields (`client_name`, `client_email`, `source_lang`, `target_lang`, `intended_use`) from the `quote_submissions` table insert, keeping only essential fields (`name`, `email`)
- **Enhanced error logging**: Added detailed console error logging with error message and code for better debugging when database insertion fails
- **Code formatting**: Improved code structure with better spacing and organizationTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 37`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9245f98cc6ff47d3b9ca0aeaebf40fdb/spark-space)

👀 [Preview Link](https://9245f98cc6ff47d3b9ca0aeaebf40fdb-spark-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9245f98cc6ff47d3b9ca0aeaebf40fdb</projectId>-->
<!--<branchName>spark-space</branchName>-->